### PR TITLE
[#22]他のユーザーの投稿が編集できてしまう

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -85,14 +85,25 @@ class PostController extends Controller
 
     public function update(Request $request, int $id) 
     {
+        //編集したい投稿の投稿IDを取得
+        $post = Post::find($id);
+
+        $user_id = Auth::id();
+
+        //存在しない投稿IDへのアクセスがあった際のリダイレクト
+        //他のユーザーの投稿を編集できないようにリダイレクト
+        if (!$post) {
+            return redirect(route('index'))->with('errorMessage', '存在しない投稿です');
+        }elseif ($post->user_id !== $user_id){
+            return redirect(route('index'))->with('errorMessage', '不正なアクセスです');
+        }
+
         //POST値のバリデーション実施
 		//required:入力必須項目
 		$request->validate([
 			'title' => 'required',
 			'text' => 'required',
 		]);
-
-        $user_id = Auth::id();
 
         //フォームで送られてきた値を取得
         $title = $request->input('title');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,9 +22,9 @@ Route::post('/add', 'PostController@add')->name('add');
 
 Route::get('/edit/post/{id}', 'PostController@editpost')->name('editpost');
 
-Route::post('/update/{id}', 'PostController@update')->name('update');
+Route::post('/update/post/{id}', 'PostController@update')->name('update');
 
-Route::post('/remove/{id}', 'PostController@remove')->name('remove');
+Route::post('/remove/post/{id}', 'PostController@remove')->name('remove');
 
 Route::get('/profile/{id}', 'UserController@showProfile')->name('user.profile');
 


### PR DESCRIPTION
他のユーザーの投稿をディベロッパーツールから編集しようとした際に、
不正なアクセスとしてリダイレクトをさせる処理を実装。
また、存在しない投稿へアクセスしようとした際も同様にリダイレクトさせる処理を実装。